### PR TITLE
Fix STACKIT documentation issues from review

### DIFF
--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/private-cloud-registry.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/private-cloud-registry.md
@@ -200,12 +200,12 @@ To use Google Artifact registry with the Mendix Operator, perform the following 
 2. Assign the *Artifact Registry Writer* (`roles/artifactregistry.writer`) role to the GCR Service Account.
 3. Allow the Mendix Operator to use the GCR Service Account by running the following command, where `PROJECT_ID` is the Google Cloud project ID, `K8S_NAMESPACE` is the Kubernetes namespace name where the Operator is installed, `KSA_NAME` is the Kubernetes Service Account name, and `GSA_NAME` is the GCP Service Account name from step 1:
 
-        ```shell
-        gcloud iam service-accounts add-iam-policy-binding \
-            --role roles/iam.workloadIdentityUser \
-            --member "serviceAccount:PROJECT_ID.svc.id.goog[K8S_NAMESPACE/KSA_NAME]" \
-            GSA_NAME@PROJECT_ID.iam.gserviceaccount.com
-        ```
+    ```shell
+    gcloud iam service-accounts add-iam-policy-binding \
+        --role roles/iam.workloadIdentityUser \
+        --member "serviceAccount:PROJECT_ID.svc.id.goog[K8S_NAMESPACE/KSA_NAME]" \
+        GSA_NAME@PROJECT_ID.iam.gserviceaccount.com
+    ```
 
 On the Kubernetes side, the Mendix Operator will use a Kubernetes Service Account to authenticate. On the GCP side, there should be a matching GCP Service Account. For simplicity, Mendix recommends using the `mendix-builder` for the service account name, on both GCP and Kubernetes sides. For more details, see the Google documentation on [using workload identities](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to).
 
@@ -285,8 +285,8 @@ Some registries impose limitations on repository names, for example the reposito
 | Field               | Value                                                                                          |
 | ------------------- | -----------------------------------------------------------------------------------------------|
 | Push URL            | registry.onstackit.cloud                                                                       |
-| Pull URL            | registry.onstackit.cloud                                                                       |         
-| Registry name       | `<stackitregistry>/<repository>`, where `<stackitregistry>` is the registry created in stackit |
+| Pull URL            | registry.onstackit.cloud                                                                       |
+| Registry name       | `<stackitregistry>/<repository>`, where `<stackitregistry>` is the registry you created in STACKIT |
 | With authentication | enabled                                                                                        |
 | User                | Username for the registry robot account                                                        |
 | Password            | Token (password) for the robot account                                                         |

--- a/content/en/docs/deployment/private-cloud/private-cloud-cluster/private-cloud-storage-plans.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-cluster/private-cloud-storage-plans.md
@@ -1907,13 +1907,13 @@ Another option is to use a dedicated object storage bucket for each environment.
 
 * Access/Secret keys used by existing environments can only be rotated manually.
 * No isolation between environments using the storage plan if using same bucket for all environments
-* Configuration parameters will not be validated and will be provided to the Mendix app as-is. If the arguments are not valid or there is an issue with permissions, the Mendix Runtime will fail to start the and deployment will appear to hang with **Replicas running** and **Runtime** showing a spinner.
+* Configuration parameters will not be validated and will be provided to the Mendix app as-is. If the arguments are not valid or there is an issue with permissions, the Mendix Runtime will fail to start, and the deployment will appear to hang with **Replicas running** and **Runtime** showing a spinner.
 
 #### Environment Isolation
 
 * The S3-compatible bucket and credentials (access and secret keys) are shared between all environments using this plan.
 * An environment can access data from other environments using this Storage Plan.
-* By creating dedicated bucket for all the environment, isolation between the environment can be achieved.
+* By creating a dedicated bucket per environment, isolation between the environments can be achieved.
 
 #### Create Workflow
 
@@ -1932,17 +1932,13 @@ When an existing environment is deleted, the Mendix Operator performs the follow
 
 In the S3 plan configuration, enter the following details:
 
-* **Endpoint** - The S3-compatible bucket's endpoint address, for example `https://object.storage.eu01.onstackit.cloud`.
-* **Access Key** and **Secret Key** - Credentials to access the bucket.
-* **Type** - Specifies if the container can be shared between environments (create an on-demand storage plan); or that the container can only be used by one environment (create a dedicated storage plan). To increase security and prevent environments from being able to access each other's data, select **Dedicated**.
-
 * **IRSA Authentication** - Set to **no**.
 * **Create bucket per environment** - Set to **No**.
 * **Create account (IAM user) per environment** - Set to **No**.
 * **Endpoint** - The S3 bucket's endpoint address.
 * **Access Key** and **Secret Key** - The credentials for the environment user account.
 * **Autogenerate prefix** - Leave it empty
-* **Share bucket between environments** - Specifies if the bucket can be shared between environments (create an on-demand storage plan); Enable this option and  the bucket will be shared between multiple environments. 
+* **Share bucket between environments** - Specifies if the bucket can be shared between environments (create an on-demand storage plan); Enable this option and the bucket will be shared between multiple environments. 
 
 ## Walkthroughs
 

--- a/content/en/docs/deployment/private-cloud/private-cloud-license-manager.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-license-manager.md
@@ -164,7 +164,7 @@ To apply the manifest to configure the ingress in the Kubernetes namespace, use 
 You can confirm that you can connect to the PCLM server using the following URLs:
 
 * `http<s>://pclm.<domain>/health` should return `HTTP 200 OK`
-
+* `https<s>://pclm.<domain>/metrics` should return `HTTP 200 OK` together with the collected server metrics
 
 ### Using the Kubernetes Service
 

--- a/content/en/docs/deployment/private-cloud/private-cloud-supported-environments.md
+++ b/content/en/docs/deployment/private-cloud/private-cloud-supported-environments.md
@@ -29,6 +29,10 @@ If you want to deploy your app to Amazon EKS, consider using the Mendix for Amaz
 * [Google Kubernetes Engine- Autopilot](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview). For more information, see [Mendix on Kubernetes Cluster: GKE Autopilot Workarounds](/developerportal/deploy/private-cloud-cluster/#gke-autopilot-workarounds)
 * [STACKIT Kubernetes Engine](https://stackit.com/en/products/runtime/stackit-kubernetes-engine)
 
+For STACKIT Kubernetes Engine, customers provision the SKE cluster, PostgreSQL Flex database(s), and Object Storage bucket(s) themselves before deploying Mendix.
+
+Any Kubernetes version offered by SKE that falls within the [Supported Versions](#supported-versions) range is supported.
+
 {{% alert color="warning" %}}
 If deploying to Red Hat OpenShift, you need to specify that specifically when creating your deployment. All other cluster types use generic Kubernetes operations.
 {{% /alert %}}
@@ -213,7 +217,7 @@ The following managed PostgreSQL databases are supported:
 * [Azure Database for PostgreSQL](https://azure.microsoft.com/en-us/services/postgresql/).
 * [Google Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres).
 * [Amazon RDS Aurora for PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.AuroraPostgreSQL.html)
-* [Stackit Postgres Flex](https://stackit.com/en/products/database/stackit-postgresql-flex)
+* [STACKIT PostgreSQL Flex](https://stackit.com/en/products/database/stackit-postgresql-flex)
 
 Amazon PostgreSQL instances require additional firewall configuration to allow connections from the Kubernetes cluster.
 

--- a/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
+++ b/content/en/docs/releasenotes/deployment/mendix-for-private-cloud.md
@@ -14,9 +14,13 @@ For information on the current status of deployment to Mendix on Kubernetes and 
 
 ### May 20, 2026
 
-#### StackIt support
+#### STACKIT support
 
-* We now officially support app deployments in Stackit kubernetes environments.
+* We now officially support deploying Mendix apps to [STACKIT Kubernetes Engine (SKE)](https://stackit.com/en/products/runtime/stackit-kubernetes-engine), with support for [STACKIT PostgreSQL Flex](https://stackit.com/en/products/database/stackit-postgresql-flex), [STACKIT Object Storage](https://docs.stackit.cloud/products/storage/object-storage/) (S3-compatible), and the [STACKIT Container Registry](https://docs.stackit.cloud/products/developer-platform/container-registry/).
+* Customers provision the SKE cluster, PostgreSQL Flex database(s), and Object Storage bucket(s) themselves before deploying Mendix. For configuration details, see [Supported Providers](/developerportal/deploy/private-cloud-supported-environments/) and [Storage Plans](/developerportal/deploy/private-cloud-storage-plans/).
+* **Known limitations on STACKIT:**
+    * STACKIT PostgreSQL Flex does not expose the `CREATEROLE` privilege, so the on-demand PostgreSQL provisioner cannot create users automatically. Use the [Dedicated JDBC plan](/developerportal/deploy/private-cloud-storage-plans/#database-jdbc) and create a dedicated database user per environment using the STACKIT CLI or API.
+    * STACKIT Object Storage does not implement `CreateUser`, `CreatePolicy`, or `CreateBucket`, so buckets must be created up front. You can either share one bucket across environments or pre-create a bucket per environment.
 
 ### May 7, 2026
 


### PR DESCRIPTION
## Summary

This PR applies the review fixes for [mendix/docs#11208](https://github.com/mendix/docs/pull/11208) so they can be merged into the `stackItdocumentation` branch before that PR lands in `development`.

### Casing standardization
- Standardize all "StackIt" / "Stackit" mentions to the official **STACKIT** all-caps spelling across the affected files.
- Rename "Stackit Postgres Flex" to "STACKIT PostgreSQL Flex" in the supported environments list.

### Release note (`mendix-for-private-cloud.md`)
- Replace the one-line STACKIT release note with a complete entry that:
  - Lists the four newly supported STACKIT services (SKE, PostgreSQL Flex, Object Storage, Container Registry) with links.
  - Calls out that customers self-provision SKE / PostgreSQL Flex / Object Storage before deploying Mendix.
  - Documents the two known limitations (CREATEROLE missing on PostgreSQL Flex; missing `CreateUser` / `CreatePolicy` / `CreateBucket` APIs on Object Storage) and how to work around them.

### Supported providers (`private-cloud-supported-environments.md`)
- Add description of the unmanaged provisioning model for SKE.
- Add a statement that any SKE-offered Kubernetes version inside the [Supported Versions](#supported-versions) range is supported.

### Storage plans (`private-cloud-storage-plans.md`)
- Remove the duplicate 3-bullet field list (Endpoint / Access Key / Type) under "Configuring the Plan" for STACKIT Object Storage; the longer field list immediately below already covers those fields.
- Fix grammar: `fail to start the and deployment` → `fail to start, and the deployment`.
- Fix grammar: `By creating dedicated bucket for all the environment` → `By creating a dedicated bucket per environment`.
- Fix double space: `Enable this option and  the bucket` → `Enable this option and the bucket`.

### Registry (`private-cloud-registry.md`)
- Revert the unrelated 4-space → 8-space reindent of the `gcloud iam service-accounts add-iam-policy-binding` block (lines 200-205) so the diff stays focused on STACKIT changes.
- Fix sentence: `the registry created in stackit` → `the registry you created in STACKIT`.
- Remove trailing whitespace from the STACKIT registry table.

### License manager (`private-cloud-license-manager.md`)
- Revert the unrelated removal of the `https<s>://pclm.<domain>/metrics` health-check bullet — that endpoint still works and the deletion was outside the scope of the STACKIT PR.

## Test plan

- [ ] CI lint passes on the updated branch
- [ ] Render the affected pages with Hugo and confirm:
  - [ ] Release note renders as a bulleted list with working links
  - [ ] Supported providers page shows the SKE provisioning note and version statement
  - [ ] Storage plans page shows a single field list under "Configuring the Plan" for STACKIT Object Storage
  - [ ] Registry page renders the gcloud snippet inside the numbered list (no broken indentation) and the STACKIT registry table has no trailing whitespace
  - [ ] License manager page shows both `/health` and `/metrics` bullets